### PR TITLE
LGU packets.

### DIFF
--- a/packets/fcu_0x7000__lgu.yml
+++ b/packets/fcu_0x7000__lgu.yml
@@ -1,0 +1,72 @@
+---
+node: 'Flight Control'
+
+podSources:
+  # FCU packet types are in here.
+  - FIRMWARE/PROJECT_CODE/LCCM655__RLOOP__FCU_CORE/NETWORKING/fcu_core__net__packet_types.h
+  # LGU status data.
+  - FIRMWARE/PROJECT_CODE/LCCM667__RLOOP__LGU/ETHERNET/lgu__ethernet.c
+
+packets:
+  - packetName: 'LGU Status'
+    prefix: 'LGU'
+    packetType: 0x7002
+    parameters:
+      - name: 'Fault Flags Root'
+        type: 'uint32'
+
+      - name: 'Fault Flags {i}'
+        type: 'uint32'
+        iterate:
+          beginGroup: true
+      - name: 'ADC Value {i}'
+        type: 'uint16'
+      - name: 'Actual Extension {i}'
+        type: 'int32'
+      - name: 'Computed Height {i}'
+        type: 'int32'
+      - name: 'Switch Extend {i}'
+        type: 'uint8'
+      - name: 'Switch Retract {i}'
+        type: 'uint8'
+      - name: 'Spare 1_{i}'
+        type: 'uint32'
+      - name: 'Spare 2_{i}'
+        type: 'uint32'
+      - name: 'Spare 3_{i}'
+        type: 'uint32'
+      - name: 'Spare 4_{i}'
+        type: 'uint32'
+        iterate:
+          end: 4 # C_LGU__NUM_ACTUATORS = 4U
+          endGroup: true
+
+  - packetName: 'LGU ADC Calibration'
+    prefix: 'ADC'
+    packetType: 0x7002
+    parameters:
+      - name: 'Value {i}'
+        type: 'uint16'
+        iterate:
+          beginGroup: true
+      - name: 'Zero {i}'
+        type: 'int32'
+      - name: 'Span {i}'
+        type: 'float32'
+      - name: 'Actual Extension {i}'
+        type: 'int32'
+      - name: 'Switch Extend {i}'
+        type: 'uint8'
+      - name: 'Switch Retract {i}'
+        type: 'uint8'
+      - name: 'Spare 1_{i}'
+        type: 'uint32'
+      - name: 'Spare 2_{i}'
+        type: 'uint32'
+      - name: 'Spare 3_{i}'
+        type: 'uint32'
+      - name: 'Spare 4_{i}'
+        type: 'uint32'
+        iterate:
+          end: 4 # C_LGU__NUM_ACTUATORS = 4U
+          endGroup: true

--- a/packets/fcu_0x7000__lgu.yml
+++ b/packets/fcu_0x7000__lgu.yml
@@ -38,6 +38,7 @@ packets:
       - name: 'Spare 4_{i}'
         type: 'uint32'
         iterate:
+          start: 1
           end: 4 # C_LGU__NUM_ACTUATORS = 4U
           endGroup: true
 
@@ -68,5 +69,6 @@ packets:
       - name: 'Spare 4_{i}'
         type: 'uint32'
         iterate:
+          start: 1
           end: 4 # C_LGU__NUM_ACTUATORS = 4U
           endGroup: true


### PR DESCRIPTION
Slightly more complicated than the pusher.

No fault flags have been defined yet for this module.
Dummy data is currently being returned by this module.
# TX Types as of pull creation
* 0x7000 - enable/disable for LGU manual controls.
```c
// If the host wants to stream data packets.
if(u32Block[0] == 1U)
{
    // Streaming on
    sLGU.sUDPDiag.eTxStreamingType = (E_NET__PACKET_T)u32Block[1];
}
else
{
    // Streaming off
    sLGU.sUDPDiag.eTxStreamingType = NET_PKT__NONE;
}
```
* 0x7001 - manual control of LGU.
```c
// Make sure we are safe
if(u32Block[0] == 0xABAB1122U)
{

    // Block 1 is the index
    // Block 2 is the direction
    vLGU_LIFT__Set_Direction((Luint8)u32Block[1], (TE_LGU__LIFT_DIRECTIONS)u32Block[2]);

    // Block 3 is the speed
    vLGU_LIFT__Set_Speed((Luint8)u32Block[1], f32Block3);

}
```